### PR TITLE
Fix bitwise_not

### DIFF
--- a/A_assembly.py
+++ b/A_assembly.py
@@ -155,10 +155,9 @@ def bitwise_xor(a, b):
     return mk_number(x ^ y)
 
 
-def bitwise_not(a, b):
+def bitwise_not(a):
     x = int(a["value"])
-    y = int(b["value"])
-    return mk_number(x ^ y)
+    return mk_number(~x)
 
 
 def size_of(s):


### PR DESCRIPTION
`bitwise_not` contained the same code as `bitwise_xor`.